### PR TITLE
feat: pull publicly

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,18 +41,19 @@ Here are some working examples of using this module:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.50.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.50.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_common_tags"></a> [common\_tags](#module\_common\_tags) | git@github.com:nclouds/terraform-aws-common-tags.git | v0.1.1 |
+| <a name="module_common_tags"></a> [common\_tags](#module\_common\_tags) | github.com/nclouds/terraform-aws-common-tags.git | v0.1.1 |
 
 ## Resources
 

--- a/local.tf
+++ b/local.tf
@@ -4,5 +4,5 @@ locals {
     replace(url, "https://", "")
   ]
 
-  assume_role_policy = length(var.oidc_fully_qualified_subjects) > 0 ? data.aws_iam_policy_document.oidc.0.json : data.aws_iam_policy_document.default.0.json
+  assume_role_policy = length(var.oidc_fully_qualified_subjects) > 0 ? data.aws_iam_policy_document.oidc[0].json : data.aws_iam_policy_document.default[0].json
 }

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ locals {
 }
 
 module "common_tags" {
-  source      = "git@github.com:nclouds/terraform-aws-common-tags.git?ref=v0.1.1"
+  source      = "github.com/nclouds/terraform-aws-common-tags.git?ref=v0.1.1"
   environment = terraform.workspace
   name        = local.identifier
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,10 @@
 terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.50.0"
+    }
+  }
+
   required_version = ">= 0.12"
 }


### PR DESCRIPTION
When trying to pull publicly from an action or profile without an ssh key, the pull module operation fails, thats the change of source for.